### PR TITLE
[ergoCubSN002] Add RX-DO-TX configuration diagnostic

### DIFF
--- a/ergoCubSN002/hardware/electronics/head-eb20-j0_2-eln.xml
+++ b/ergoCubSN002/hardware/electronics/head-eb20-j0_2-eln.xml
@@ -23,6 +23,16 @@
                 <param name="maxTimeOfDOactivity">      300                 </param>
                 <param name="maxTimeOfTXactivity">      300                 </param>
                 <param name="TXrateOfRegularROPs">      1                   </param>
+
+                <group name="LOGGING">
+                    <group name="IMMEDIATE">
+                        <param name="emitRXDOTXoverflow">       false       </param>
+                    </group>
+                    <group name="PERIODIC">
+                        <param name="period">                   10.0        </param>
+                        <param name="emitRXDOTXstatistics">     true        </param>
+                    </group>
+                </group>
             </group>
         </group>
 

--- a/ergoCubSN002/hardware/electronics/head-eb21-j3-eln.xml
+++ b/ergoCubSN002/hardware/electronics/head-eb21-j3-eln.xml
@@ -23,6 +23,16 @@
                 <param name="maxTimeOfDOactivity">      300                 </param>
                 <param name="maxTimeOfTXactivity">      300                 </param>
                 <param name="TXrateOfRegularROPs">      1                   </param>
+
+                <group name="LOGGING">
+                    <group name="IMMEDIATE">
+                        <param name="emitRXDOTXoverflow">       false       </param>
+                    </group>
+                    <group name="PERIODIC">
+                        <param name="period">                   10.0        </param>
+                        <param name="emitRXDOTXstatistics">     true        </param>
+                    </group>
+                </group>
             </group>
         </group>
 

--- a/ergoCubSN002/hardware/electronics/left_arm-eb2-j0_1-eln.xml
+++ b/ergoCubSN002/hardware/electronics/left_arm-eb2-j0_1-eln.xml
@@ -23,6 +23,16 @@
                 <param name="maxTimeOfDOactivity">      300                 </param>   
                 <param name="maxTimeOfTXactivity">      300                 </param>                
                 <param name="TXrateOfRegularROPs">      1                   </param> 
+
+                <group name="LOGGING">
+                    <group name="IMMEDIATE">
+                        <param name="emitRXDOTXoverflow">       false       </param>
+                    </group>
+                    <group name="PERIODIC">
+                        <param name="period">                   10.0        </param>
+                        <param name="emitRXDOTXstatistics">     true        </param>
+                    </group>
+                </group>
             </group>              
         </group>                 
         

--- a/ergoCubSN002/hardware/electronics/left_arm-eb23-j7_10-eln.xml
+++ b/ergoCubSN002/hardware/electronics/left_arm-eb23-j7_10-eln.xml
@@ -23,6 +23,16 @@
                 <param name="maxTimeOfDOactivity">      300                 </param>
                 <param name="maxTimeOfTXactivity">      300                 </param>
                 <param name="TXrateOfRegularROPs">      1                   </param>
+
+                <group name="LOGGING">
+                    <group name="IMMEDIATE">
+                        <param name="emitRXDOTXoverflow">       false       </param>
+                    </group>
+                    <group name="PERIODIC">
+                        <param name="period">                   10.0        </param>
+                        <param name="emitRXDOTXstatistics">     true        </param>
+                    </group>
+                </group>
             </group>
         </group>
 

--- a/ergoCubSN002/hardware/electronics/left_arm-eb25-j11_12-eln.xml
+++ b/ergoCubSN002/hardware/electronics/left_arm-eb25-j11_12-eln.xml
@@ -23,6 +23,16 @@
                 <param name="maxTimeOfDOactivity">      300                           </param>
                 <param name="maxTimeOfTXactivity">      300                           </param>
                 <param name="TXrateOfRegularROPs">      1                             </param>
+
+                <group name="LOGGING">
+                    <group name="IMMEDIATE">
+                        <param name="emitRXDOTXoverflow">       false       </param>
+                    </group>
+                    <group name="PERIODIC">
+                        <param name="period">                   10.0        </param>
+                        <param name="emitRXDOTXstatistics">     true        </param>
+                    </group>
+                </group>
             </group>
         </group>
 

--- a/ergoCubSN002/hardware/electronics/left_arm-eb31-j4_6-eln.xml
+++ b/ergoCubSN002/hardware/electronics/left_arm-eb31-j4_6-eln.xml
@@ -23,6 +23,16 @@
                 <param name="maxTimeOfDOactivity">      300                 </param>
                 <param name="maxTimeOfTXactivity">      300                 </param>
                 <param name="TXrateOfRegularROPs">      1                   </param>
+
+                <group name="LOGGING">
+                    <group name="IMMEDIATE">
+                        <param name="emitRXDOTXoverflow">       false       </param>
+                    </group>
+                    <group name="PERIODIC">
+                        <param name="period">                   10.0        </param>
+                        <param name="emitRXDOTXstatistics">     true        </param>
+                    </group>
+                </group>
             </group>
         </group>
 

--- a/ergoCubSN002/hardware/electronics/left_arm-eb4-j2_3-eln.xml
+++ b/ergoCubSN002/hardware/electronics/left_arm-eb4-j2_3-eln.xml
@@ -23,6 +23,16 @@
                 <param name="maxTimeOfDOactivity">      300                 </param>   
                 <param name="maxTimeOfTXactivity">      300                 </param>                
                 <param name="TXrateOfRegularROPs">      1                   </param> 
+
+                <group name="LOGGING">
+                    <group name="IMMEDIATE">
+                        <param name="emitRXDOTXoverflow">       false       </param>
+                    </group>
+                    <group name="PERIODIC">
+                        <param name="period">                   10.0        </param>
+                        <param name="emitRXDOTXstatistics">     true        </param>
+                    </group>
+                </group>
             </group>              
         </group>                 
         

--- a/ergoCubSN002/hardware/electronics/left_leg-eb8-j0_3-eln.xml
+++ b/ergoCubSN002/hardware/electronics/left_leg-eb8-j0_3-eln.xml
@@ -23,6 +23,16 @@
                 <param name="maxTimeOfDOactivity">      500                 </param>
                 <param name="maxTimeOfTXactivity">      200                 </param>
                 <param name="TXrateOfRegularROPs">      1                   </param> 
+
+                <group name="LOGGING">
+                    <group name="IMMEDIATE">
+                        <param name="emitRXDOTXoverflow">       false       </param>
+                    </group>
+                    <group name="PERIODIC">
+                        <param name="period">                   10.0        </param>
+                        <param name="emitRXDOTXstatistics">     true        </param>
+                    </group>
+                </group>
             </group>              
         </group>                 
         

--- a/ergoCubSN002/hardware/electronics/left_leg-eb9-j4_5-eln.xml
+++ b/ergoCubSN002/hardware/electronics/left_leg-eb9-j4_5-eln.xml
@@ -23,6 +23,16 @@
                 <param name="maxTimeOfDOactivity">      300                 </param>   
                 <param name="maxTimeOfTXactivity">      300                 </param>                
                 <param name="TXrateOfRegularROPs">      1                   </param> 
+
+                <group name="LOGGING">
+                    <group name="IMMEDIATE">
+                        <param name="emitRXDOTXoverflow">       false       </param>
+                    </group>
+                    <group name="PERIODIC">
+                        <param name="period">                   10.0        </param>
+                        <param name="emitRXDOTXstatistics">     true        </param>
+                    </group>
+                </group>
             </group>              
         </group>                 
         

--- a/ergoCubSN002/hardware/electronics/right_arm-eb1-j0_1-eln.xml
+++ b/ergoCubSN002/hardware/electronics/right_arm-eb1-j0_1-eln.xml
@@ -23,6 +23,16 @@
                 <param name="maxTimeOfDOactivity">      300                 </param>   
                 <param name="maxTimeOfTXactivity">      300                 </param>                
                 <param name="TXrateOfRegularROPs">      1                   </param> 
+
+                <group name="LOGGING">
+                    <group name="IMMEDIATE">
+                        <param name="emitRXDOTXoverflow">       false       </param>
+                    </group>
+                    <group name="PERIODIC">
+                        <param name="period">                   10.0        </param>
+                        <param name="emitRXDOTXstatistics">     true        </param>
+                    </group>
+                </group>
             </group>              
         </group>                 
         

--- a/ergoCubSN002/hardware/electronics/right_arm-eb22-j7_10-eln.xml
+++ b/ergoCubSN002/hardware/electronics/right_arm-eb22-j7_10-eln.xml
@@ -23,6 +23,16 @@
                 <param name="maxTimeOfDOactivity">      300                           </param>
                 <param name="maxTimeOfTXactivity">      300                           </param>
                 <param name="TXrateOfRegularROPs">      1                             </param>
+
+                <group name="LOGGING">
+                    <group name="IMMEDIATE">
+                        <param name="emitRXDOTXoverflow">       false       </param>
+                    </group>
+                    <group name="PERIODIC">
+                        <param name="period">                   10.0        </param>
+                        <param name="emitRXDOTXstatistics">     true        </param>
+                    </group>
+                </group>
             </group>
         </group>
 

--- a/ergoCubSN002/hardware/electronics/right_arm-eb24-j11_12-eln.xml
+++ b/ergoCubSN002/hardware/electronics/right_arm-eb24-j11_12-eln.xml
@@ -23,6 +23,16 @@
                 <param name="maxTimeOfDOactivity">      300                           </param>
                 <param name="maxTimeOfTXactivity">      300                           </param>
                 <param name="TXrateOfRegularROPs">      1                             </param>
+
+                <group name="LOGGING">
+                    <group name="IMMEDIATE">
+                        <param name="emitRXDOTXoverflow">       false       </param>
+                    </group>
+                    <group name="PERIODIC">
+                        <param name="period">                   10.0        </param>
+                        <param name="emitRXDOTXstatistics">     true        </param>
+                    </group>
+                </group>
             </group>
         </group>
 

--- a/ergoCubSN002/hardware/electronics/right_arm-eb3-j2_3-eln.xml
+++ b/ergoCubSN002/hardware/electronics/right_arm-eb3-j2_3-eln.xml
@@ -23,6 +23,16 @@
                 <param name="maxTimeOfDOactivity">      300                 </param>   
                 <param name="maxTimeOfTXactivity">      300                 </param>                
                 <param name="TXrateOfRegularROPs">      1                   </param> 
+
+                <group name="LOGGING">
+                    <group name="IMMEDIATE">
+                        <param name="emitRXDOTXoverflow">       false       </param>
+                    </group>
+                    <group name="PERIODIC">
+                        <param name="period">                   10.0        </param>
+                        <param name="emitRXDOTXstatistics">     true        </param>
+                    </group>
+                </group>
             </group>              
         </group>                 
         

--- a/ergoCubSN002/hardware/electronics/right_arm-eb30-j4_6-eln.xml
+++ b/ergoCubSN002/hardware/electronics/right_arm-eb30-j4_6-eln.xml
@@ -23,6 +23,16 @@
                 <param name="maxTimeOfDOactivity">      300                 </param>
                 <param name="maxTimeOfTXactivity">      300                 </param>
                 <param name="TXrateOfRegularROPs">      1                   </param>
+
+                <group name="LOGGING">
+                    <group name="IMMEDIATE">
+                        <param name="emitRXDOTXoverflow">       false       </param>
+                    </group>
+                    <group name="PERIODIC">
+                        <param name="period">                   10.0        </param>
+                        <param name="emitRXDOTXstatistics">     true        </param>
+                    </group>
+                </group>
             </group>
         </group>
 

--- a/ergoCubSN002/hardware/electronics/right_leg-eb6-j0_3-eln.xml
+++ b/ergoCubSN002/hardware/electronics/right_leg-eb6-j0_3-eln.xml
@@ -23,6 +23,16 @@
                 <param name="maxTimeOfDOactivity">      500                 </param>
                 <param name="maxTimeOfTXactivity">      200                 </param>
                 <param name="TXrateOfRegularROPs">      1                   </param>
+
+                <group name="LOGGING">
+                    <group name="IMMEDIATE">
+                        <param name="emitRXDOTXoverflow">       false       </param>
+                    </group>
+                    <group name="PERIODIC">
+                        <param name="period">                   10.0        </param>
+                        <param name="emitRXDOTXstatistics">     true        </param>
+                    </group>
+                </group>
             </group>              
         </group>                 
         

--- a/ergoCubSN002/hardware/electronics/right_leg-eb7-j4_5-eln.xml
+++ b/ergoCubSN002/hardware/electronics/right_leg-eb7-j4_5-eln.xml
@@ -23,6 +23,16 @@
                 <param name="maxTimeOfDOactivity">      300                 </param>   
                 <param name="maxTimeOfTXactivity">      300                 </param>                
                 <param name="TXrateOfRegularROPs">      1                   </param> 
+
+                <group name="LOGGING">
+                    <group name="IMMEDIATE">
+                        <param name="emitRXDOTXoverflow">       false       </param>
+                    </group>
+                    <group name="PERIODIC">
+                        <param name="period">                   10.0        </param>
+                        <param name="emitRXDOTXstatistics">     true        </param>
+                    </group>
+                </group>
             </group>              
         </group>                 
         

--- a/ergoCubSN002/hardware/electronics/torso-eb5-j0_2-eln.xml
+++ b/ergoCubSN002/hardware/electronics/torso-eb5-j0_2-eln.xml
@@ -23,6 +23,16 @@
                 <param name="maxTimeOfDOactivity">      300                 </param>   
                 <param name="maxTimeOfTXactivity">      300                 </param>                
                 <param name="TXrateOfRegularROPs">      1                   </param> 
+
+                <group name="LOGGING">
+                    <group name="IMMEDIATE">
+                        <param name="emitRXDOTXoverflow">       false       </param>
+                    </group>
+                    <group name="PERIODIC">
+                        <param name="period">                   10.0        </param>
+                        <param name="emitRXDOTXstatistics">     true        </param>
+                    </group>
+                </group>
             </group>              
         </group>                 
         


### PR DESCRIPTION
This PR fixes:

- https://github.com/robotology/icub-main/issues/1024

With this added section, the warnings that the time RX-DO-TX has exceeded have been disabled, while the statistics (min, average and max duration) of each phase are printed every 10 sec. 

Tested on ergoCubSN002, see:

- https://github.com/robotology/icub-main/issues/1024#issuecomment-2965931677

cc @S-Dafarra @pattacini @Nicogene 